### PR TITLE
Fix plugins

### DIFF
--- a/processcore/CMakeLists.txt
+++ b/processcore/CMakeLists.txt
@@ -23,7 +23,7 @@ set(ksysguard_LIB_SRCS
 ecm_qt_declare_logging_category(ksysguard_LIB_SRCS HEADER processcore_debug.h IDENTIFIER LIBKSYSGUARD_PROCESSCORE CATEGORY_NAME org.kde.libksysguard.processcore
     DESCRIPTION "libksysguard (processcore)" EXPORT LIBKSYSGUARD)
 
-add_library(processcore STATIC ${ksysguard_LIB_SRCS})
+add_library(processcore SHARED ${ksysguard_LIB_SRCS})
 add_library(ProcessCore ALIAS processcore)
 
 generate_export_header(processcore)
@@ -62,8 +62,7 @@ target_include_directories(processcore
 #install(TARGETS processcore EXPORT libksysguardLibraryTargets ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
 
 #add_subdirectory(declarative)
-# Unfortunately, it doesn't work yet.
-#add_subdirectory(plugins)
+add_subdirectory(plugins)
 
 ########### install files ###############
 

--- a/processcore/extended_process_list.cpp
+++ b/processcore/extended_process_list.cpp
@@ -546,7 +546,7 @@ QList<ProcessAttribute *> ExtendedProcesses::extendedAttributes() const
 
 void ExtendedProcesses::Private::loadPlugins()
 {
-    const QList<KPluginMetaData> listMetaData = KPluginMetaData::findPlugins(QStringLiteral("ksysguard5/process"));
+    const QList<KPluginMetaData> listMetaData = KPluginMetaData::findPlugins(QStringLiteral("ksysguard6/process"));
     // instantiate all plugins
     for (const auto &pluginMetaData : listMetaData) {
         qCDebug(LIBKSYSGUARD_PROCESSCORE) << "loading plugin" << pluginMetaData.name();

--- a/processcore/plugins/network/CMakeLists.txt
+++ b/processcore/plugins/network/CMakeLists.txt
@@ -18,4 +18,4 @@ configure_file(networkconstants.h.in networkconstants.h @ONLY)
 add_library(ksysguard_plugin_network MODULE ${networkplugin_SRCS})
 target_link_libraries(ksysguard_plugin_network Qt::Core Qt::DBus KF6::CoreAddons KF6::I18n ProcessCore)
 
-install(TARGETS ksysguard_plugin_network DESTINATION ${KDE_INSTALL_PLUGINDIR}/ksysguard5/process)
+install(TARGETS ksysguard_plugin_network DESTINATION ${KDE_INSTALL_PLUGINDIR}/ksysguard6/process)

--- a/processcore/plugins/network/helper/CMakeLists.txt
+++ b/processcore/plugins/network/helper/CMakeLists.txt
@@ -16,13 +16,13 @@ set_target_properties(ksgrd_network_helper PROPERTIES CXX_STANDARD 17 CXX_STANDA
 # Why can't CMake fix this itself?'
 target_link_libraries(ksgrd_network_helper pthread)
 
-install(TARGETS ksgrd_network_helper DESTINATION ${KDE_INSTALL_LIBEXECDIR}/ksysguard5)
+install(TARGETS ksgrd_network_helper DESTINATION ${KDE_INSTALL_LIBEXECDIR}/ksysguard6)
 
 if (Libcap_FOUND)
     install(
         CODE "execute_process(
         COMMAND ${SETCAP_EXECUTABLE}
         CAP_NET_RAW=+ep
-        \$ENV{DESTDIR}${KDE_INSTALL_FULL_LIBEXECDIR}/ksysguard5/ksgrd_network_helper)"
+        \$ENV{DESTDIR}${KDE_INSTALL_FULL_LIBEXECDIR}/ksysguard6/ksgrd_network_helper)"
     )
 endif()

--- a/processcore/plugins/network/networkconstants.h.in
+++ b/processcore/plugins/network/networkconstants.h.in
@@ -2,6 +2,6 @@
 
 namespace NetworkConstants {
 
-static const QString HelperLocation = QStringLiteral("@KDE_INSTALL_FULL_LIBEXECDIR@/ksysguard5/ksgrd_network_helper");
+static const QString HelperLocation = QStringLiteral("@KDE_INSTALL_FULL_LIBEXECDIR@/ksysguard6/ksgrd_network_helper");
 
 }

--- a/processcore/plugins/nvidia/CMakeLists.txt
+++ b/processcore/plugins/nvidia/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(ksysguard_plugin_nvidia MODULE nvidia.cpp nvidia.h)
 target_link_libraries(ksysguard_plugin_nvidia Qt::Core ProcessCore KF6::I18n KF6::CoreAddons)
-install(TARGETS ksysguard_plugin_nvidia DESTINATION ${KDE_INSTALL_PLUGINDIR}/ksysguard5/process)
+install(TARGETS ksysguard_plugin_nvidia DESTINATION ${KDE_INSTALL_PLUGINDIR}/ksysguard6/process)


### PR DESCRIPTION
As mentioned in #4, build issues arise from processcore being static and KPluginFactory being unable to load statically built plugins as is. This PR changes processcore back to shared to fix build & loading as well as adjust a few paths that hadn't been updated yet.

Draft because processcore being shared will conflict with system libksysguard (which also provides libprocesscore) if installed.

Alternatively, kcoreaddons [suggest](https://invent.kde.org/frameworks/kcoreaddons/-/commit/34ff4a8778be2b23c06571cb092c7355cebe24e9) static plugins being possible but I haven't yet been able to figure out how to get it working (seems to silently fail loading? I only did a cursory check with strace)