### PR TITLE
Fix confusion of sensors with SensorSocketAgent

### DIFF
--- a/ksgrd/SensorAgent.cpp
+++ b/ksgrd/SensorAgent.cpp
@@ -185,14 +185,14 @@ void SensorAgent::executeCommand()
 #if SA_TRACE
         qCDebug(LIBKSYSGUARD_KSGRD) << ">> " << req->request() << "(" << mInputFIFO.count() << "/" << mProcessingFIFO.count() << ")" << endl;
 #endif
+        // add request to processing FIFO.
+        // Note that this means that mProcessingFIFO is now responsible for managing the memory for it.
+        mProcessingFIFO.enqueue(req);
+
         // send request to daemon
         QString cmdWithNL = req->request() + '\n';
         if (!writeMsg(cmdWithNL.toLatin1().constData(), cmdWithNL.length()))
             qCDebug(LIBKSYSGUARD_KSGRD) << "SensorAgent::writeMsg() failed";
-
-        // add request to processing FIFO.
-        // Note that this means that mProcessingFIFO is now responsible for managing the memory for it.
-        mProcessingFIFO.enqueue(req);
     }
 }
 


### PR DESCRIPTION
When SensorSocketAgent is used, calling writeMsg immediately triggers msgSent which calls executeCommand again. In the end the nested executeCommand call manages to enqueue its request to mProcessingFIFO before the request of the original call is enqueued.

Finally, when the response for the first sent command is received it is matched with the second command and vice-versa. This resulted in sensor labels getting mixed up.