### PR TITLE
Update usages of Qt6 deprecations to the recommended alternatives

### DIFF
--- a/formatter/Formatter.cpp
+++ b/formatter/Formatter.cpp
@@ -399,7 +399,7 @@ static QString formatNumber(const QVariant &value, Unit unit, MetricPrefix prefi
         amount /= std::pow(unitOrder(unit), adjusted - unit);
     }
 
-    const int precision = (value.type() != QVariant::Double && adjusted <= unit) ? 0 : 1;
+    const int precision = (value.typeId() != QMetaType::Double && adjusted <= unit) ? 0 : 1;
     const QString text = QLocale().toString(amount, 'f', precision);
 
     return unitFormat(adjusted).subs(text).toString();

--- a/gui/SensorDisplayLib/SensorDisplay.cpp
+++ b/gui/SensorDisplayLib/SensorDisplay.cpp
@@ -145,7 +145,7 @@ bool SensorDisplay::eventFilter( QObject *object, QEvent *event )
   if ( event->type() == QEvent::MouseButtonPress) {
     QMouseEvent *e = static_cast<QMouseEvent *> (event);
     if( e->button() == Qt::RightButton ) {
-      showContextMenu( mapFromGlobal( e->globalPos() ) );
+      showContextMenu( mapFromGlobal( e->globalPosition() ).toPoint() );
       return true;
     }
   } 
@@ -473,5 +473,3 @@ QString SensorProperties::regExpName() const
 {
   return mRegExpName;
 }
-
-

--- a/gui/WorkSheet.cpp
+++ b/gui/WorkSheet.cpp
@@ -478,7 +478,7 @@ void WorkSheet::dragMoveEvent( QDragMoveEvent *event )
 {
     /* Find the sensor display that is supposed to get the drop
      * event and replace or add sensor. */
-    const QPoint globalPos = mapToGlobal( event->pos() );
+    const QPoint globalPos = mapToGlobal( event->position().toPoint() );
     for ( int i = 0; i < mGridLayout->count(); i++ ) {
         KSGRD::SensorDisplay* display = static_cast<KSGRD::SensorDisplay*>(mGridLayout->itemAt(i)->widget());
         const QRect widgetRect = QRect( display->mapToGlobal( QPoint( 0, 0 ) ),
@@ -515,7 +515,7 @@ void WorkSheet::dropEvent( QDropEvent *event )
 
     /* Find the sensor display that is supposed to get the drop
      * event and replace or add sensor. */
-    const QPoint globalPos = mapToGlobal( event->pos() );
+    const QPoint globalPos = mapToGlobal( event->position().toPoint() );
     for ( int i = 0; i < mGridLayout->count(); i++ ) {
         KSGRD::SensorDisplay* display = static_cast<KSGRD::SensorDisplay*>(mGridLayout->itemAt(i)->widget());
         const QSize displaySize = display->size();
@@ -810,5 +810,3 @@ float WorkSheet::updateInterval() const
     else
         return 0;
 }
-
-

--- a/processui/ProcessModel.cpp
+++ b/processui/ProcessModel.cpp
@@ -1407,7 +1407,7 @@ QVariant ProcessModel::data(const QModelIndex &index, int role) const
         case Qt::TextAlignmentRole: {
             KSysGuard::Process *process = reinterpret_cast<KSysGuard::Process *>(index.internalPointer());
             const QVariant value = d->mExtraAttributes[attr]->data(process);
-            if (value.canConvert(QMetaType::LongLong) && static_cast<QMetaType::Type>(value.type()) != QMetaType::QString) {
+            if (value.canConvert(QMetaType(QMetaType::LongLong)) && value.typeId() != QMetaType::QString) {
                 return (int)(Qt::AlignRight | Qt::AlignVCenter);
             }
             return (int)(Qt::AlignLeft | Qt::AlignVCenter);
@@ -1489,7 +1489,7 @@ QVariant ProcessModel::data(const QModelIndex &index, int role) const
             return formatMemoryInfo(process->vmSize(), d->mUnits, true);
         case HeadingSharedMemory:
             if (process->vmRSS() - process->vmURSS() <= 0 || process->vmURSS() == -1)
-                return QVariant(QVariant::String);
+                return QVariant(QMetaType(QMetaType::QString));
             return formatMemoryInfo(process->vmRSS() - process->vmURSS(), d->mUnits);
         case HeadingStartTime: {
             // NOTE: the next 6 lines are the same as in the next occurrence of 'case HeadingStartTime:' => keep in sync or remove duplicate code
@@ -1565,11 +1565,11 @@ QVariant ProcessModel::data(const QModelIndex &index, int role) const
             return formatMemoryInfo(process->pixmapBytes() / 1024, d->mUnits, true);
         case HeadingXTitle: {
             if (!process->hasManagedGuiWindow())
-                return QVariant(QVariant::String);
+                return QVariant(QMetaType(QMetaType::QString));
 
             WindowInfo *w = d->mPidToWindowInfo.value(process->pid(), NULL);
             if (!w)
-                return QVariant(QVariant::String);
+                return QVariant(QMetaType(QMetaType::QString));
             else
                 return w->name;
         }
@@ -1901,7 +1901,7 @@ QVariant ProcessModel::data(const QModelIndex &index, int role) const
             }
         }
         default:
-            return QVariant(QVariant::String);
+            return QVariant(QMetaType(QMetaType::QString));
         }
     }
     case Qt::TextAlignmentRole:
@@ -1947,7 +1947,7 @@ QVariant ProcessModel::data(const QModelIndex &index, int role) const
             return (qlonglong)(process->userTime() + process->sysTime());
         case HeadingMemory:
             if (process->vmRSS() == 0)
-                return QVariant(QVariant::String);
+                return QVariant(QMetaType(QMetaType::QString));
             if (process->vmURSS() == -1) {
                 return (qlonglong)process->vmRSS();
             } else {
@@ -1957,7 +1957,7 @@ QVariant ProcessModel::data(const QModelIndex &index, int role) const
             return (qlonglong)process->vmSize();
         case HeadingSharedMemory:
             if (process->vmRSS() - process->vmURSS() < 0 || process->vmURSS() == -1)
-                return QVariant(QVariant::String);
+                return QVariant(QMetaType(QMetaType::QString));
             return (qlonglong)(process->vmRSS() - process->vmURSS());
         case HeadingStartTime:
             return process->startTime(); // 2015-01-03, gregormi: can maybe be replaced with something better later

--- a/processui/processdetails/MemoryMapsTab.cpp
+++ b/processui/processdetails/MemoryMapsTab.cpp
@@ -65,7 +65,7 @@ public:
                 if (column >= 0 && column < dataItem.count()) {
                     const QVariant data = dataItem.at(column);
                     Q_ASSERT(data.isValid());
-                    if (role == Qt::DisplayRole && data.type() != QVariant::String) {
+                    if (role == Qt::DisplayRole && data.typeId() != QMetaType::QString) {
                         if (column == Column_Start || column == Column_End || column == Column_Offset) {
                             return QString::number(data.toULongLong(), 16); // show in hex
                         }


### PR DESCRIPTION
There were a handful of usages of members in the code that are marked as obsolete/deprecated since Qt6 (see https://doc.qt.io/qt-6/qvariant-obsolete.html).
This updates these to the recommended alternatives for future-proofing – no functionality should have changes.