### PR TITLE
Fix build with GCC 15.2. Forces PIC in the Formatter module.

### DIFF
--- a/formatter/CMakeLists.txt
+++ b/formatter/CMakeLists.txt
@@ -46,6 +46,8 @@ target_include_directories(Formatter
 
 target_compile_definitions(Formatter PRIVATE -DTRANSLATION_DOMAIN=\"KSysGuardFormatter\")
 
+set_target_properties(Formatter PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 add_subdirectory(declarative)
 
 #install(TARGETS Formatter EXPORT libksysguardLibraryTargets ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})


### PR DESCRIPTION
PIC must be enabled otherwise it won't link:

```
[ 55%] Linking CXX shared library ../bin/libprocesscore_ksg6.so
/usr/lib64/gcc/x86_64-suse-linux/15/../../../../x86_64-suse-linux/bin/ld: ../lib/libFormatter.a(Formatter.cpp.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
/usr/lib64/gcc/x86_64-suse-linux/15/../../../../x86_64-suse-linux/bin/ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
make[2]: *** [processcore/CMakeFiles/processcore_ksg6.dir/build.make:382: bin/libprocesscore_ksg6.so.4.98.0] Error 1
make[1]: *** [CMakeFiles/Makefile2:8987: processcore/CMakeFiles/processcore_ksg6.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

This patch enforces PIC (position independent code).
As for the explanation AFAIK GCC 15 tightened enforcement of rules around position-independent code (PIC) when building shared libraries that link against static archives (.a files). Before, GCC/linker allowed a few non-PIC objects to slip through under certain conditions; now it’s stricter. Now it's needed that all static libraries included in shared libs to be compiled with `-fPIC`.