### PR TITLE
Plugin improvements

### DIFF
--- a/gui/SensorDisplayLib/ProcessController.cpp
+++ b/gui/SensorDisplayLib/ProcessController.cpp
@@ -30,6 +30,7 @@
 #include "ProcessController.h"
 #include "../processui/ksysguardprocesslist.h"
 #include "../processcore/processes.h"
+#include "../processcore/extended_process_attribute.h"
 
 //#define DO_MODELCHECK
 #ifdef DO_MODELCHECK
@@ -95,6 +96,12 @@ ProcessController::restoreSettings(QDomElement& element)
     int filterState = element.attribute(QStringLiteral("filterState"), QString::number((int)ProcessFilter::AllProcesses)).toUInt();
     mProcessList->setState((ProcessFilter::State)filterState);
 
+    // allow plugins to load settings
+    for (auto plugin : mProcessList->processModel()->extraAttributes())
+    {
+        plugin->loadSettingsLegacy(element);
+    }
+
     SensorDisplay::restoreSettings(element);
     return result;
 }
@@ -118,6 +125,12 @@ bool ProcessController::saveSettings(QDomDocument& doc, QDomElement& element)
     element.setAttribute(QStringLiteral("showTooltips"), mProcessList->processModel()->isShowingTooltips());
     element.setAttribute(QStringLiteral("normalizeCPUUsage"), mProcessList->processModel()->isNormalizedCPUUsage());
     element.setAttribute(QStringLiteral("filterState"), (int)(mProcessList->state()));
+
+    // allow plugins to save settings
+    for (auto plugin : mProcessList->processModel()->extraAttributes())
+    {
+        plugin->saveSettingsLegacy(element);
+    }
 
     SensorDisplay::saveSettings(doc, element);
 

--- a/processcore/CMakeLists.txt
+++ b/processcore/CMakeLists.txt
@@ -10,6 +10,7 @@ set(ksysguard_LIB_SRCS
    processes.cpp
    process.cpp
    process_attribute.cpp
+   extended_process_attribute.cpp
    processes_local_p.cpp processes_local_p.h
    processes_remote_p.cpp processes_remote_p.h
    processes_base_p.cpp processes_base_p.h

--- a/processcore/extended_process_attribute.cpp
+++ b/processcore/extended_process_attribute.cpp
@@ -1,0 +1,127 @@
+/*
+    SPDX-FileCopyrightText: 2026 Juho Ovaska <ovaska.juho@gmail.com>
+
+    SPDX-License-Identifier: LGPL-2.0-or-later
+*/
+
+#include "extended_process_attribute.h"
+#include <qvariant.h>
+
+using namespace KSysGuard;
+
+class Q_DECL_HIDDEN KSysGuard::ExtendedProcessAttribute::Private
+{
+public:
+    ExtendedProcessAttribute::ProcessModelInterface stub;
+    ExtendedProcessAttribute::ProcessModelInterface *iface = &stub;
+};
+
+ExtendedProcessAttribute::ProcessModelInterface::~ProcessModelInterface()
+{
+}
+
+void ExtendedProcessAttribute::ProcessModelInterface::saveSettings(KConfigGroup &cg)
+{
+    (void)cg;
+}
+
+void ExtendedProcessAttribute::ProcessModelInterface::saveSettingsLegacy(QDomElement &element)
+{
+    (void)element;
+}
+
+void ExtendedProcessAttribute::ProcessModelInterface::loadSettings(const KConfigGroup &cg)
+{
+    (void)cg;
+}
+
+void ExtendedProcessAttribute::ProcessModelInterface::loadSettingsLegacy(QDomElement &element)
+{
+    (void)element;
+}
+
+void ExtendedProcessAttribute::ProcessModelInterface::setupMenu(QMenu &menu)
+{
+    (void)menu;
+}
+
+void ExtendedProcessAttribute::ProcessModelInterface::checkMenu(QAction *action)
+{
+    (void)action;
+}
+
+QVariant ExtendedProcessAttribute::ProcessModelInterface::getTooltip()
+{
+    return QVariant();
+}
+
+QVariant ExtendedProcessAttribute::ProcessModelInterface::getWhatsThis()
+{
+    return QVariant();
+}
+
+ExtendedProcessAttribute::ExtendedProcessAttribute(const QString &id, QObject *parent)
+    : ProcessAttribute(id, QString(), parent)
+    , d(new Private)
+{
+}
+
+ExtendedProcessAttribute::ExtendedProcessAttribute(const QString &id, const QString &name, QObject *parent)
+    : ProcessAttribute(id, name, parent)
+    , d(new Private)
+{
+}
+
+ExtendedProcessAttribute::~ExtendedProcessAttribute()
+{
+}
+
+void ExtendedProcessAttribute::setInterface(ProcessModelInterface *iface)
+{
+    if (iface != nullptr) {
+        d->iface = iface;
+    } else {
+        d->iface = &d->stub;
+    }
+}
+
+void ExtendedProcessAttribute::saveSettings(KConfigGroup &cg)
+{
+    d->iface->saveSettings(cg);
+}
+
+void ExtendedProcessAttribute::saveSettingsLegacy(QDomElement &element)
+{
+    d->iface->saveSettingsLegacy(element);
+}
+
+void ExtendedProcessAttribute::loadSettings(const KConfigGroup &cg)
+{
+    d->iface->loadSettings(cg);
+}
+
+void ExtendedProcessAttribute::loadSettingsLegacy(QDomElement &element)
+{
+    d->iface->loadSettingsLegacy(element);
+}
+
+
+void ExtendedProcessAttribute::setupMenu(QMenu &menu)
+{
+    d->iface->setupMenu(menu);
+}
+
+void ExtendedProcessAttribute::checkMenu(QAction *action)
+{
+    d->iface->checkMenu(action);
+}
+
+QVariant ExtendedProcessAttribute::getTooltip()
+{
+    return d->iface->getTooltip();
+}
+
+QVariant ExtendedProcessAttribute::getWhatsThis()
+{
+    return d->iface->getWhatsThis();
+}

--- a/processcore/extended_process_attribute.h
+++ b/processcore/extended_process_attribute.h
@@ -1,0 +1,74 @@
+/*
+    SPDX-FileCopyrightText: 2026 Juho Ovaska <ovaska.juho@gmail.com>
+
+    SPDX-License-Identifier: LGPL-2.0-or-later
+*/
+#pragma once
+
+#include "process_attribute.h"
+
+#include <QScopedPointer>
+
+class QMenu;
+class QAction;
+class QDomElement;
+class KConfigGroup;
+
+namespace KSysGuard
+{
+
+class PROCESSCORE_EXPORT ExtendedProcessAttribute : public ProcessAttribute
+{
+public:
+    class ProcessModelInterface
+    {
+    public:
+        virtual ~ProcessModelInterface();
+        virtual void saveSettings(KConfigGroup &cg);
+        virtual void saveSettingsLegacy(QDomElement &cg);
+        virtual void loadSettings(const KConfigGroup &cg);
+        virtual void loadSettingsLegacy(QDomElement &cg);
+        virtual void setupMenu(QMenu &menu);
+        virtual void checkMenu(QAction *action);
+        virtual QVariant getTooltip();
+        virtual QVariant getWhatsThis();
+    };
+
+    ExtendedProcessAttribute(const QString &id, QObject *parent);
+    ExtendedProcessAttribute(const QString &id, const QString &name, QObject *parent);
+
+    ~ExtendedProcessAttribute() override;
+
+    // sets up the interface between process attribute and the process model
+    void setInterface(ProcessModelInterface *iface);
+
+    // saves plugin settings to config group
+    void saveSettings(KConfigGroup &cg);
+
+    // saves plugin settings to XML element
+    void saveSettingsLegacy(QDomElement &element);
+
+    // loads plugin settings from config group
+    void loadSettings(const KConfigGroup &cg);
+
+    // loads plugin settings from XML element
+    void loadSettingsLegacy(QDomElement &element);
+
+    // sets up column context menu
+    void setupMenu(QMenu &menu);
+
+    // checks menu action
+    void checkMenu(QAction *action);
+
+    // returns the tooltip shown when column is hovered over
+    QVariant getTooltip();
+
+    // returns the Qt::WhatsThisRole decription
+    QVariant getWhatsThis();
+
+private:
+    class Private;
+    QScopedPointer<Private> d;
+};
+
+}

--- a/processcore/extended_process_list.cpp
+++ b/processcore/extended_process_list.cpp
@@ -1,5 +1,6 @@
 /*
     SPDX-FileCopyrightText: 2019 David Edmundson <davidedmundson@kde.org>
+    SPDX-FileCopyrightText: 2026 Juho Ovaska <ovaska.juho@gmail.com>
 
     SPDX-License-Identifier: LGPL-2.0-or-later
 */
@@ -12,6 +13,7 @@
 
 #include "process.h"
 #include "process_attribute.h"
+#include "extended_process_attribute.h"
 #include "process_data_provider.h"
 #include "processcore_debug.h"
 
@@ -532,12 +534,18 @@ ExtendedProcesses::~ExtendedProcesses()
 
 QList<ProcessAttribute *> ExtendedProcesses::attributes() const
 {
-    return d->m_coreAttributes + extendedAttributes();
+    QList<ProcessAttribute *> attrs;
+    attrs += d->m_coreAttributes;
+    for (auto attr : extendedAttributes())
+    {
+        attrs += attr;
+    }
+    return attrs;
 }
 
-QList<ProcessAttribute *> ExtendedProcesses::extendedAttributes() const
+QList<ExtendedProcessAttribute *> ExtendedProcesses::extendedAttributes() const
 {
-    QList<ProcessAttribute *> rc;
+    QList<ExtendedProcessAttribute *> rc;
     for (auto p : std::as_const(d->m_providers)) {
         rc << p->attributes();
     }

--- a/processcore/extended_process_list.h
+++ b/processcore/extended_process_list.h
@@ -15,13 +15,14 @@
 namespace KSysGuard
 {
 class ProcessAttribute;
+class ExtendedProcessAttribute;
 
 class PROCESSCORE_EXPORT ExtendedProcesses : public KSysGuard::Processes
 {
     Q_OBJECT
 public:
     QList<ProcessAttribute *> attributes() const;
-    QList<ProcessAttribute *> extendedAttributes() const;
+    QList<ExtendedProcessAttribute *> extendedAttributes() const;
 
     /**
      * Returns a single shared instance of the process list for when used in multiple views

--- a/processcore/plugins/network/network.cpp
+++ b/processcore/plugins/network/network.cpp
@@ -16,10 +16,41 @@
 #include <KLocalizedString>
 #include <KPluginFactory>
 
+#include "extended_process_attribute.h"
 #include "networkconstants.h"
 #include "networklogging.h"
 
 using namespace KSysGuard;
+
+class NetworkPlugin::inboundInterface : public ExtendedProcessAttribute::ProcessModelInterface
+{
+    QVariant getTooltip() override
+    {
+        return i18n(
+    "Displays the total inbound network activity to the process.");
+    }
+
+    QVariant getWhatsThis() override
+    {
+        return i18n(
+    "<qt>Total inbound network activity.");
+    }
+};
+
+class NetworkPlugin::outboundInterface : public ExtendedProcessAttribute::ProcessModelInterface
+{
+    QVariant getTooltip() override
+    {
+        return i18n(
+    "Displays the total outbound network activity from the process.");
+    }
+
+    QVariant getWhatsThis() override
+    {
+        return i18n(
+    "<qt>Total outbound network activity.");
+    }
+};
 
 NetworkPlugin::NetworkPlugin(QObject *parent, const QVariantList &args)
     : ProcessDataProvider(parent, args)
@@ -33,14 +64,20 @@ NetworkPlugin::NetworkPlugin(QObject *parent, const QVariantList &args)
     qCDebug(KSYSGUARD_PLUGIN_NETWORK) << "Network plugin loading";
     qCDebug(KSYSGUARD_PLUGIN_NETWORK) << "Found helper at" << qPrintable(executable);
 
-    m_inboundSensor = new ProcessAttribute(QStringLiteral("netInbound"), i18nc("@title", "Download Speed"), this);
+    m_inboundSensor = new ExtendedProcessAttribute(QStringLiteral("netInbound"), i18nc("@title", "Download Speed"), this);
     m_inboundSensor->setShortName(i18nc("@title", "Download"));
     m_inboundSensor->setUnit(KSysGuard::UnitByteRate);
     m_inboundSensor->setVisibleByDefault(true);
-    m_outboundSensor = new ProcessAttribute(QStringLiteral("netOutbound"), i18nc("@title", "Upload Speed"), this);
+    m_outboundSensor = new ExtendedProcessAttribute(QStringLiteral("netOutbound"), i18nc("@title", "Upload Speed"), this);
     m_outboundSensor->setShortName(i18nc("@title", "Upload"));
     m_outboundSensor->setUnit(KSysGuard::UnitByteRate);
     m_outboundSensor->setVisibleByDefault(true);
+
+    m_inboundSensorInterface.reset(new inboundInterface());
+    m_inboundSensor->setInterface(m_inboundSensorInterface.get());
+
+    m_outboundSensorInterface.reset(new outboundInterface());
+    m_outboundSensor->setInterface(m_outboundSensorInterface.get());
 
     addProcessAttribute(m_inboundSensor);
     addProcessAttribute(m_outboundSensor);
@@ -81,6 +118,10 @@ NetworkPlugin::NetworkPlugin(QObject *parent, const QVariantList &args)
             m_outboundSensor->setData(process, bytesOut);
         }
     });
+}
+
+NetworkPlugin::~NetworkPlugin()
+{
 }
 
 void NetworkPlugin::handleEnabledChanged(bool enabled)

--- a/processcore/plugins/network/network.h
+++ b/processcore/plugins/network/network.h
@@ -6,8 +6,10 @@
 
 #pragma once
 
-#include "../processcore/process_attribute.h"
+#include <QScopedPointer>
+
 #include "../processcore/process_data_provider.h"
+#include "../processcore/extended_process_attribute.h"
 
 class QProcess;
 
@@ -16,11 +18,18 @@ class NetworkPlugin : public KSysGuard::ProcessDataProvider
     Q_OBJECT
 public:
     NetworkPlugin(QObject *parent, const QVariantList &args);
+    ~NetworkPlugin() override;
 
     void handleEnabledChanged(bool enabled) override;
 
 private:
-    QProcess *m_process = nullptr;
-    KSysGuard::ProcessAttribute *m_inboundSensor = nullptr;
-    KSysGuard::ProcessAttribute *m_outboundSensor = nullptr;
+    QProcess *m_process;
+    KSysGuard::ExtendedProcessAttribute *m_inboundSensor;
+    KSysGuard::ExtendedProcessAttribute *m_outboundSensor;
+    
+    class inboundInterface;
+    class outboundInterface;
+
+    QScopedPointer<inboundInterface> m_inboundSensorInterface;
+    QScopedPointer<outboundInterface> m_outboundSensorInterface;
 };

--- a/processcore/plugins/nvidia/CMakeLists.txt
+++ b/processcore/plugins/nvidia/CMakeLists.txt
@@ -1,3 +1,14 @@
-add_library(ksysguard_plugin_nvidia MODULE nvidia.cpp nvidia.h)
-target_link_libraries(ksysguard_plugin_nvidia Qt::Core ProcessCore KF6::I18n KF6::CoreAddons)
+include(ECMQtDeclareLoggingCategory)
+
+set(nvidiaplugin_SRCS nvidia.cpp)
+
+ecm_qt_declare_logging_category(nvidiaplugin_SRCS
+    HEADER nvidialogging.h
+    IDENTIFIER KSYSGUARD_PLUGIN_NVIDIA
+    CATEGORY_NAME org.kde.ksysguard.plugin.nvidia
+)
+
+add_library(ksysguard_plugin_nvidia MODULE ${nvidiaplugin_SRCS})
+target_link_libraries(ksysguard_plugin_nvidia Qt::Core Qt::Widgets Qt::Xml ProcessCore KF6::I18n KF6::CoreAddons KF6::ConfigCore)
+
 install(TARGETS ksysguard_plugin_nvidia DESTINATION ${KDE_INSTALL_PLUGINDIR}/ksysguard6/process)

--- a/processcore/plugins/nvidia/nvidia.cpp
+++ b/processcore/plugins/nvidia/nvidia.cpp
@@ -7,9 +7,13 @@
 
 #include "nvidia.h"
 
+#include <QMenu>
 #include <QDebug>
 #include <QLibrary>
+#include <QDomElement>
+#include <QLoggingCategory>
 
+#include <KConfigGroup>
 #include <KLocalizedString>
 #include <KPluginFactory>
 
@@ -21,11 +25,13 @@
 
 #include <cassert>
 
+#include "nvidialogging.h"
+
 #include "nvml.h"
 
 using namespace KSysGuard;
 
-class nvmlLib {
+class NvidiaPlugin::nvmlLib {
 public:
     struct nvmlFuncs
     {
@@ -73,14 +79,14 @@ NV_FUNC(nvmlDeviceGetMPSComputeRunningProcesses)
         nvmlFuncs funcs{};
         bool failed = false;
 #define NV_STR(name) #name
-#define NV_FUNC(name) do {                                                             \
-            auto *ptr = m_lib.resolve(NV_STR(name));                                   \
-            if (ptr == nullptr) {                                                      \
-                qDebug() << "ERROR: Failed to resolve NVML symbol '" NV_STR(name) "'"; \
-                failed = true;                                                         \
-            } else {                                                                   \
-                funcs.name = reinterpret_cast<decltype(funcs.name)>(ptr);              \
-            }                                                                          \
+#define NV_FUNC(name) do {                                                                                       \
+            auto *ptr = m_lib.resolve(NV_STR(name));                                                             \
+            if (ptr == nullptr) {                                                                                \
+                qCWarning(KSYSGUARD_PLUGIN_NVIDIA) << "ERROR: Failed to resolve NVML symbol '" NV_STR(name) "'"; \
+                failed = true;                                                                                   \
+            } else {                                                                                             \
+                funcs.name = reinterpret_cast<decltype(funcs.name)>(ptr);                                        \
+            }                                                                                                    \
         } while (0);
 NV_FUNC(nvmlInit)
 NV_FUNC(nvmlShutdown)
@@ -100,7 +106,7 @@ NV_FUNC(nvmlDeviceGetMPSComputeRunningProcesses)
             auto ret = funcs.nvmlInit();
             if (ret != NVML_SUCCESS)
             {
-                qDebug() << "ERROR: Failed to initialize NVML, nvmlInit() returned " << ret;
+                qCWarning(KSYSGUARD_PLUGIN_NVIDIA) << "ERROR: Failed to initialize NVML, nvmlInit() returned " << ret;
                 failed = true;
             }
         }
@@ -136,15 +142,16 @@ private:
     nvmlFuncs m_funcs;
 };
 
-class nvmlDetail {
+class NvidiaPlugin::nvmlDetail {
     struct processInfo {
         unsigned int gpuUtil;
         unsigned long long memUsage;
     };
 
 public:
-    explicit nvmlDetail(const nvmlLib &lib)
-        : m_lib(lib)
+    explicit nvmlDetail(const NvidiaPlugin &plugin, const nvmlLib &lib)
+        : m_plugin(plugin)
+        , m_lib(lib)
         , m_pidListSelect(false)
         , m_bufferSize(0)
     {
@@ -207,6 +214,11 @@ public:
             pidsNow().cbegin(), pidsNow().cend(),
             std::inserter(m_pidListDelta, m_pidListDelta.begin())
         );
+    }
+
+    unsigned int numGpus() const
+    {
+        return m_gpus.size();
     }
 
     void removedPids(std::function<void(unsigned int pid)> &&callback)
@@ -291,7 +303,12 @@ private:
         {
             auto &item = buf[i];
             auto &info = getInfo(item.pid);
-            info.gpuUtil += static_cast<double>(item.smUtil) / static_cast<double>(m_gpus.size()) + 0.5;
+            double usage = static_cast<double>(item.smUtil);
+            if (m_plugin.isNormalizedGPUUsage())
+            {
+                usage /= static_cast<double>(m_gpus.size());
+            }
+            info.gpuUtil = usage + 0.5;
             if (timestamp < item.timeStamp)
             {
                 timestamp = item.timeStamp;
@@ -332,6 +349,7 @@ private:
         }
     }
 
+    const NvidiaPlugin &m_plugin;
     const nvmlLib &m_lib;
 
     // used to select between m_pidList1/2 to avoid moves/reallocations
@@ -354,8 +372,109 @@ private:
     std::unordered_map<unsigned int, processInfo> m_infoList;
 };
 
+class NvidiaPlugin::usageInterface : public ExtendedProcessAttribute::ProcessModelInterface
+{
+public:
+    explicit usageInterface(NvidiaPlugin &plugin)
+        : m_plugin(plugin)
+        , m_normalizeAction(nullptr)
+    {}
+
+    ~usageInterface() override
+    {}
+
+    void saveSettings(KConfigGroup &cg) override
+    {
+        cg.writeEntry("normalizeGPUUsage", m_plugin.isNormalizedGPUUsage());
+    }
+
+    void saveSettingsLegacy(QDomElement &element) override
+    {
+        element.setAttribute(QStringLiteral("normalizeGPUUsage"), m_plugin.isNormalizedGPUUsage());
+    }
+
+    void loadSettings(const KConfigGroup &cg) override
+    {
+        m_plugin.setNormalizedGPUUsage(cg.readEntry("normalizeGPUUsage", true));
+    }
+
+    void loadSettingsLegacy(QDomElement &element) override
+    {
+        int normalizeGPUUsage = element.attribute(QStringLiteral("normalizeGPUUsage"), "1").toUInt();
+        m_plugin.setNormalizedGPUUsage(normalizeGPUUsage);
+    }
+
+    void setupMenu(QMenu &menu) override
+    {
+        m_normalizeAction = new QAction(&menu);
+        m_normalizeAction->setText(i18n("Divide GPU usage by number of GPUs"));
+        m_normalizeAction->setCheckable(true);
+        m_normalizeAction->setChecked(m_plugin.isNormalizedGPUUsage());
+        menu.addSeparator();
+        menu.addAction(m_normalizeAction);
+    }
+
+    void checkMenu(QAction *action) override
+    {
+        if (action == m_normalizeAction)
+        {
+            m_plugin.setNormalizedGPUUsage(m_normalizeAction->isChecked());
+        }
+    }
+
+    QVariant getTooltip() override
+    {
+        if (m_plugin.numGpus() == 1)
+        {
+            return i18n("The current GPU usage of the process.");
+        }
+        else if (m_plugin.isNormalizedGPUUsage())
+        {
+            return i18np("The current total GPU usage of the process, divided by the %1 GPU in the machine.",
+                            "The current total GPU usage of the process, divided by the %1 GPUs in the machine.",
+                            m_plugin.numGpus());
+        }
+        else
+        {
+            return i18n("The current total CPU usage of the process.");
+        }
+        
+    }
+
+    QVariant getWhatsThis() override
+    {
+        return i18n("<qt>The current total CPU usage of the process.");
+    }
+ 
+private:
+    NvidiaPlugin &m_plugin;
+    QAction *m_normalizeAction;
+};
+
+class NvidiaPlugin::memoryInterface : public ExtendedProcessAttribute::ProcessModelInterface
+{
+public:
+    explicit memoryInterface(NvidiaPlugin &plugin)
+        : m_plugin(plugin)
+    {}
+
+    QVariant getTooltip() override
+    {
+        return i18n("The current total VRAM allocations of the process. (graphics + compute)");
+    }
+
+    QVariant getWhatsThis() override
+    {
+        return i18n("<qt>The current VRAM allocations of the process.");
+    }
+
+private:
+    NvidiaPlugin &m_plugin;
+};
+
 NvidiaPlugin::NvidiaPlugin(QObject *parent, const QVariantList &args)
     : ProcessDataProvider(parent, args)
+    , m_normalizeUsage(true) // default to true
 {
     m_nvmlLib = std::make_unique<nvmlLib>();
     if (!m_nvmlLib->tryLoad()) {
@@ -363,10 +482,16 @@ NvidiaPlugin::NvidiaPlugin(QObject *parent, const QVariantList &args)
         return;
     }
 
-    m_usage = new ProcessAttribute(QStringLiteral("nvidia_usage"), i18n("GPU Usage"), this);
+    m_usage = new ExtendedProcessAttribute(QStringLiteral("nvidia_usage"), i18n("GPU Usage"), this);
     m_usage->setUnit(KSysGuard::UnitPercent);
-    m_memory = new ProcessAttribute(QStringLiteral("nvidia_memory"), i18n("GPU Memory"), this);
+    m_memory = new ExtendedProcessAttribute(QStringLiteral("nvidia_memory"), i18n("GPU Memory"), this);
     m_memory->setUnit(KSysGuard::UnitByte);
+
+    m_usageInterface = std::make_unique<usageInterface>(*this);
+    m_usage->setInterface(m_usageInterface.get());
+
+    m_memoryInterface = std::make_unique<memoryInterface>(*this);
+    m_memory->setInterface(m_memoryInterface.get());
 
     addProcessAttribute(m_usage);
     addProcessAttribute(m_memory);
@@ -382,7 +507,7 @@ void NvidiaPlugin::handleEnabledChanged(bool enabled)
         return;
 
     if (enabled) {
-        m_nvmlDetail = std::make_unique<nvmlDetail>(*m_nvmlLib.get());
+        m_nvmlDetail = std::make_unique<nvmlDetail>(*this, *m_nvmlLib.get());
         m_nvmlDetail->loadGpus();
     } else {
         m_nvmlDetail.reset();
@@ -415,6 +540,48 @@ void NvidiaPlugin::update()
             m_memory->setData(proc, memory);
         }
     });
+}
+
+unsigned int NvidiaPlugin::numGpus()
+{
+    if (m_nvmlDetail)
+    {
+        return m_nvmlDetail->numGpus();
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+bool NvidiaPlugin::isNormalizedGPUUsage() const
+{
+    return m_normalizeUsage;
+}
+
+void NvidiaPlugin::setNormalizedGPUUsage(bool normalize)
+{
+    m_normalizeUsage = normalize;
+}
+
+KSysGuard::Unit NvidiaPlugin::getMemoryUnits()
+{
+    if (m_memory != nullptr)
+    {
+        return m_memory->unit();
+    }
+    else
+    {
+        return KSysGuard::UnitInvalid;
+    }
+}
+
+void NvidiaPlugin::setMemoryUnits(KSysGuard::Unit unit)
+{
+    if (m_memory != nullptr)
+    {
+        return m_memory->setUnit(unit);
+    }
 }
 
 K_PLUGIN_FACTORY_WITH_JSON(PluginFactory, "nvidia.json", registerPlugin<NvidiaPlugin>();)

--- a/processcore/plugins/nvidia/nvidia.h
+++ b/processcore/plugins/nvidia/nvidia.h
@@ -7,27 +7,45 @@
 
 #pragma once
 
-#include "../processcore/process_attribute.h"
 #include "../processcore/process_data_provider.h"
+#include "../processcore/extended_process_attribute.h"
 
-class nvmlLib;
-class nvmlDetail;
+#include <memory>
 
 class NvidiaPlugin : public KSysGuard::ProcessDataProvider
 {
     Q_OBJECT
 public:
     NvidiaPlugin(QObject *parent, const QVariantList &args);
-    ~NvidiaPlugin();
+    ~NvidiaPlugin() override;
 
     void handleEnabledChanged(bool enabled) override;
 
 private:
     void update() override;
 
-    KSysGuard::ProcessAttribute *m_usage = nullptr;
-    KSysGuard::ProcessAttribute *m_memory = nullptr;
+    unsigned int numGpus();
+
+    bool isNormalizedGPUUsage() const;
+    void setNormalizedGPUUsage(bool normalize);
+
+    KSysGuard::Unit getMemoryUnits();
+    void setMemoryUnits(KSysGuard::Unit unit);
+
+    bool m_normalizeUsage;
+
+    KSysGuard::ExtendedProcessAttribute *m_usage = nullptr;
+    KSysGuard::ExtendedProcessAttribute *m_memory = nullptr;
+
+    class nvmlLib;
+    class nvmlDetail;
 
     std::unique_ptr<nvmlLib> m_nvmlLib;
     std::unique_ptr<nvmlDetail> m_nvmlDetail;
+
+    class usageInterface;
+    class memoryInterface;
+ 
+    std::unique_ptr<usageInterface> m_usageInterface;
+    std::unique_ptr<memoryInterface> m_memoryInterface;
 };

--- a/processcore/process_data_provider.cpp
+++ b/processcore/process_data_provider.cpp
@@ -6,6 +6,7 @@
 
 #include "process_data_provider.h"
 #include "process_attribute.h"
+#include "extended_process_attribute.h"
 #include "processes.h"
 
 using namespace KSysGuard;
@@ -14,7 +15,7 @@ class Q_DECL_HIDDEN KSysGuard::ProcessDataProvider::Private
 {
 public:
     KSysGuard::Processes *m_processes;
-    QList<ProcessAttribute *> m_attributes;
+    QList<ExtendedProcessAttribute *> m_attributes;
     bool m_enabled = false;
 };
 
@@ -49,7 +50,7 @@ KSysGuard::Process *ProcessDataProvider::getProcess(long pid)
     return process;
 }
 
-QList<ProcessAttribute *> ProcessDataProvider::attributes() const
+QList<ExtendedProcessAttribute *> ProcessDataProvider::attributes() const
 {
     return d->m_attributes;
 }
@@ -59,7 +60,7 @@ bool ProcessDataProvider::enabled() const
     return d->m_enabled;
 }
 
-void ProcessDataProvider::addProcessAttribute(ProcessAttribute *attribute)
+void ProcessDataProvider::addProcessAttribute(ExtendedProcessAttribute *attribute)
 {
     d->m_attributes << attribute;
     connect(attribute, &ProcessAttribute::enabledChanged, this, [this](bool enabled) {

--- a/processcore/process_data_provider.h
+++ b/processcore/process_data_provider.h
@@ -15,7 +15,7 @@ namespace KSysGuard
 {
 class Processes;
 class Process;
-class ProcessAttribute;
+class ExtendedProcessAttribute;
 
 /**
  * Base class for a process plugin data
@@ -45,7 +45,7 @@ public:
      * A list of all process attributes provided by this plugin
      * It is expected to remain constant through the lifespan of this class
      */
-    QList<ProcessAttribute *> attributes() const;
+    QList<ExtendedProcessAttribute *> attributes() const;
 
     /**
      * Called when processes should be updated if manually polled
@@ -77,7 +77,7 @@ protected:
      * Register a new process attribute
      * Process attributes should be created in the plugin constructor and must live for the duration the plugin
      */
-    void addProcessAttribute(ProcessAttribute *attribute);
+    void addProcessAttribute(ExtendedProcessAttribute *attribute);
 
 private:
     class Private;

--- a/processui/ProcessModel.cpp
+++ b/processui/ProcessModel.cpp
@@ -16,6 +16,7 @@
 #include "../processcore/formatter.h"
 #include "../processcore/process.h"
 #include "../processcore/process_attribute.h"
+#include "../processcore/extended_process_attribute.h"
 #include "../processcore/process_data_provider.h"
 
 #include "processui_debug.h"
@@ -35,6 +36,8 @@
 #include <QTextDocument>
 #include <kcolorscheme.h>
 #include <kiconloader.h>
+#include <qnamespace.h>
+#include <qvariant.h>
 
 #define HEADING_X_ICON_SIZE 16
 #define MILLISECONDS_TO_SHOW_RED_FOR_KILLED_PROCESS 2000
@@ -365,7 +368,7 @@ KSysGuard::Processes *ProcessModel::processController() const
     return d->mProcesses.get();
 }
 
-const QVector<KSysGuard::ProcessAttribute *> ProcessModel::extraAttributes() const
+const QVector<KSysGuard::ExtendedProcessAttribute *> ProcessModel::extraAttributes() const
 {
     return d->mExtraAttributes;
 }
@@ -680,6 +683,11 @@ int ProcessModel::rowCount(const QModelIndex &parent) const
 int ProcessModel::columnCount(const QModelIndex &) const
 {
     return d->mHeadings.count() + d->mExtraAttributes.count();
+}
+
+int ProcessModel::baseColumnCount() const
+{
+    return d->mHeadings.count();
 }
 
 bool ProcessModel::hasChildren(const QModelIndex &parent = QModelIndex()) const
@@ -1040,6 +1048,10 @@ QVariant ProcessModel::headerData(int section, Qt::Orientation orientation, int 
         switch (role) {
         case Qt::DisplayRole:
             return d->mExtraAttributes[attr]->shortName();
+        case Qt::ToolTipRole:
+            return d->mExtraAttributes[attr]->getTooltip();
+        case Qt::WhatsThisRole:
+            return d->mExtraAttributes[attr]->getWhatsThis();
         }
         return QVariant();
     }

--- a/processui/ProcessModel.h
+++ b/processui/ProcessModel.h
@@ -20,6 +20,7 @@ namespace KSysGuard
 class Processes;
 class Process;
 class ProcessAttribute;
+class ExtendedProcessAttribute;
 }
 
 class ProcessModelPrivate;
@@ -54,6 +55,9 @@ public:
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
     QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
     QModelIndex parent(const QModelIndex &index) const override;
+
+    // returns number of non-plugin columns
+    int baseColumnCount() const;
 
     bool hasChildren(const QModelIndex &parent) const override;
     /** Returns if (left < right), used by the sort-filter proxy model to sort the columns */
@@ -118,7 +122,7 @@ public:
     KSysGuard::Processes *processController() const; // The processes instance
 
     /** Returns the list of extra attributes provided by plugins */
-    const QVector<KSysGuard::ProcessAttribute *> extraAttributes() const;
+    const QVector<KSysGuard::ExtendedProcessAttribute *> extraAttributes() const;
 
     /** Convenience function to get the number of processes.
      *

--- a/processui/ProcessModel_p.h
+++ b/processui/ProcessModel_p.h
@@ -201,7 +201,7 @@ public:
     /** Storage for the history entries. We need one per percentage column. */
     QHash<KSysGuard::Process *, QVector<ProcessModel::PercentageHistoryEntry>> mMapProcessCPUHistory;
 
-    QVector<KSysGuard::ProcessAttribute *> mExtraAttributes;
+    QVector<KSysGuard::ExtendedProcessAttribute *> mExtraAttributes;
 
 #if HAVE_XRES
     bool mHaveXRes; ///< True if the XRes extension is available at run time

--- a/processui/ksysguardprocesslist.cpp
+++ b/processui/ksysguardprocesslist.cpp
@@ -51,6 +51,7 @@
 #include "processdetails/ProcessDetailsDialog.h"
 #include "ReniceDlg.h"
 #include "../processcore/process_attribute.h"
+#include "../processcore/extended_process_attribute.h"
 #include "../processcore/process_controller.h"
 #include "scripting.h"
 #include "ui_ProcessWidgetUI.h"
@@ -916,6 +917,18 @@ void KSysGuardProcessList::showColumnContextMenu(const QPoint &point)
         }
     }
 
+    // let plugins add items to context menu
+    KSysGuard::ExtendedProcessAttribute *plugin = nullptr;
+    {
+        int pluginIndex = index - d->mModel.baseColumnCount();
+        auto pluginAttrs = d->mModel.extraAttributes();
+        if ((pluginIndex >= 0) && (pluginIndex < pluginAttrs.count()))
+        {
+            plugin = pluginAttrs[pluginIndex];
+            plugin->setupMenu(menu);
+        }
+    }
+
     menu.addSeparator();
     actionShowTooltips = new QAction(&menu);
     actionShowTooltips->setCheckable(true);
@@ -989,6 +1002,10 @@ void KSysGuardProcessList::showColumnContextMenu(const QPoint &point)
         default:
             break;
         }
+
+    // allow plugins to handle actions
+    } else if (plugin != nullptr) {
+        plugin->checkMenu(result);
     }
 
     int i = result->data().toInt();
@@ -1472,6 +1489,12 @@ void KSysGuardProcessList::saveSettings(KConfigGroup &cg)
     // If we change, say, the header between versions of ksysguard, then the old headerState settings will not be valid.
     // The version property lets us keep track of which version we are
     cg.writeEntry("version", PROCESSHEADERVERSION);
+
+    // trigger plugins to save settings
+    for (auto plugin : d->mModel.extraAttributes())
+    {
+        plugin->saveSettings(cg);
+    }
 }
 
 void KSysGuardProcessList::loadSettings(const KConfigGroup &cg)
@@ -1489,6 +1512,12 @@ void KSysGuardProcessList::loadSettings(const KConfigGroup &cg)
     int version = cg.readEntry("version", 0);
     if (version == PROCESSHEADERVERSION) { // If the header has changed, the old settings are no longer valid.  Only restore if version is the same
         restoreHeaderState(cg.readEntry("headerState", QByteArray()));
+    }
+
+    // trigger plugins to load settings
+    for (auto plugin : d->mModel.extraAttributes())
+    {
+        plugin->loadSettings(cg);
     }
 }
 


### PR DESCRIPTION
This PR aims to improve plugin interaction with the rest of KSysguard. At the moment this is done by extending the `ProcessAttribute` class into `ExtendedProcessAttribute` to provide callbacks that are used by KSysguard to integrate better with the plugin.

Currently, the following things are supported:

1. Saving/loading settings to/from KSysguard config
2. Modification of the column context menu
3. Specification Tooltip/WhatIsThis? values for plugin columns.

Additions to NVIDIA & network plugins:
- Added tooltips and whatisthis? values for all columns provided by plugins
- Added option to specify whether GPU usage is scaled by the number of GPUs in the context menu (same as with CPU usage)

I'll keep this as a draft for now as it could probably use quite a bit of cleaning up.